### PR TITLE
Various fixes and workaround for auto-conforming protocols

### DIFF
--- a/Sources/COW/COW.swift
+++ b/Sources/COW/COW.swift
@@ -248,3 +248,17 @@ extension _Box: Codable where Contents: Codable {
   }
   
 }
+
+// Idea of workaround credits to 
+// https://github.com/JosephDuffy/HashableMacro/commit/250787664a63ceff83c1c9b5e30e574ada568f2f.
+#if swift(<5.9.2)
+public protocol COWStorageEquatableWorkaround {
+  static func equalsWorkaround(lhs: Self, rhs: Self) -> Bool
+}
+
+public extension Equatable where Self: COWStorageEquatableWorkaround {
+  static func == (lhs: Self, rhs: Self) -> Bool {
+    equalsWorkaround(lhs: lhs, rhs: rhs)
+  }
+}
+#endif

--- a/Sources/COW/COW.swift
+++ b/Sources/COW/COW.swift
@@ -250,7 +250,7 @@ extension _Box: Codable where Contents: Codable {
 }
 
 // Idea of workaround credits to 
-// https://github.com/JosephDuffy/HashableMacro/commit/250787664a63ceff83c1c9b5e30e574ada568f2f.
+// https://github.com/JosephDuffy/HashableMacro/commit/250787664a63ceff83c1c9b5e30e574ada568f2f
 #if swift(<5.9.2)
 public protocol COWStorageEquatableWorkaround {
   static func equalsWorkaround(lhs: Self, rhs: Self) -> Bool

--- a/Sources/COWMacros/COWExpansionFactory.swift
+++ b/Sources/COWMacros/COWExpansionFactory.swift
@@ -274,7 +274,7 @@ internal class COWExpansionFactory<Context: MacroExpansionContext> {
       .filter { !$0.isStatic && !$0.isMutating && !$0.returnTypeEquals(to: "Void") }
       .forEach { members.append(MemberBlockItemSyntax(decl: $0)) }
     
-    guard let body = nestingEqualFunc.as(FunctionDeclSyntax.self)!.body else {
+    guard let body = nestingEqualFunc.body else {
       // Could this ever happen (i.e. a function declaration without
       // implementation in struct is invalid)?
       fatalError()

--- a/Sources/COWMacros/COWExpansionFactory.swift
+++ b/Sources/COWMacros/COWExpansionFactory.swift
@@ -304,7 +304,7 @@ internal class COWExpansionFactory<Context: MacroExpansionContext> {
     #endif
   }
   
-  private func forwardCodingKeysForDerivedStorage(
+  private func forwardCodingKeysForDerivedStorageIfNeeded(
     members: inout [MemberBlockItemSyntax],
     protocols: inout [InheritedTypeSyntax],
     associatedMembers: inout [DeclSyntax]
@@ -390,9 +390,11 @@ internal class COWExpansionFactory<Context: MacroExpansionContext> {
     applyEquatableWorkaroundIfNeeded(members: &members, protocols: &protocols)
     
     var associatedMembers = [DeclSyntax]()
-    forwardCodingKeysForDerivedStorage(members: &members,
-                                       protocols: &protocols,
-                                       associatedMembers: &associatedMembers)
+    forwardCodingKeysForDerivedStorageIfNeeded(
+        members: &members,
+        protocols: &protocols,
+        associatedMembers: &associatedMembers
+    )
     
     let inheritance = InheritanceClauseSyntax {
       InheritedTypeListSyntax {

--- a/Sources/COWMacros/COWExpansionFactory.swift
+++ b/Sources/COWMacros/COWExpansionFactory.swift
@@ -245,11 +245,9 @@ internal class COWExpansionFactory<Context: MacroExpansionContext> {
     }
     
     // Bail out if `appliedStructDecl` does not manually implement `==`.
-    guard appliedStructDecl.memberBlock.members
-      .lazy
-      .map(\.decl)
-      .compactMap({$0.as(FunctionDeclSyntax.self)})
-      .contains(where: {$0.likelyToConformToEquatable(for: appliedStructDecl)}) else {
+    guard appliedStructDecl.memberBlock.members.contains(where: {
+     $0.decl.as(FunctionDeclSyntax.self)?.likelyToConformToEquatable(for: appliedStructDecl) ?? false
+    }) else {
       return
     }
     

--- a/Sources/COWMacros/COWExpansionFactory.swift
+++ b/Sources/COWMacros/COWExpansionFactory.swift
@@ -228,7 +228,7 @@ internal class COWExpansionFactory<Context: MacroExpansionContext> {
   // compiler bug that breaks the build).
   // https://forums.swift.org/t/macro-multiple-matching-functions-xyz-error-though-the-expanded-code-has-no-duplicate-functions-and-compiles/68700/4
   // FIXME: remove the workaround when the compiler bug is fixed.
-  private func applyEquatableWorkaroundForDerivedStorage(
+  private func applyEquatableWorkaroundIfNeeded(
     members: inout [MemberBlockItemSyntax],
     protocols: inout [InheritedTypeSyntax]
   ) {
@@ -387,7 +387,7 @@ internal class COWExpansionFactory<Context: MacroExpansionContext> {
     }
     
     var protocols = appliedStructDecl.collectAutoSynthesizingProtocolConformance()
-    applyEquatableWorkaroundForDerivedStorage(members: &members, protocols: &protocols)
+    applyEquatableWorkaroundIfNeeded(members: &members, protocols: &protocols)
     
     var associatedMembers = [DeclSyntax]()
     forwardCodingKeysForDerivedStorage(members: &members,

--- a/Sources/COWMacros/COWMacros.swift
+++ b/Sources/COWMacros/COWMacros.swift
@@ -5,7 +5,8 @@ import SwiftSyntaxMacros
 @_implementationOnly import SwiftSyntaxBuilder
 @_implementationOnly import SwiftDiagnostics
 
-private let defaultStorageName: TokenSyntax = "_$storage"
+let defaultStorageTypeName: TokenSyntax = "_$COWStorage"
+let defaultStorageName: TokenSyntax = "_$storage"
 
 // MARK: - NameLookupable
 
@@ -101,7 +102,8 @@ public struct COWMacro:
       return []
     }
     
-    let storageTypeDecl = factory.getStorageTypeDecl()
+    let storageTypeAndAssociatedMembers = factory.getStorageTypeDecl()
+    let storageTypeDecl = storageTypeAndAssociatedMembers.storageType
     
     let storageName = structDecl.copyOnWriteStorageName ?? defaultStorageName
     
@@ -128,6 +130,9 @@ public struct COWMacro:
     structDecl.addIfNeeded(storageMemberDecl, to: &expansions)
     if let explicitInitializerDecl {
       structDecl.addIfNeeded(explicitInitializerDecl, to: &expansions)
+    }
+    storageTypeAndAssociatedMembers.additionalMembers?.forEach {
+      structDecl.addIfNeeded($0, to: &expansions)
     }
     
     return expansions

--- a/Sources/COWMacros/COWMacros.swift
+++ b/Sources/COWMacros/COWMacros.swift
@@ -5,8 +5,8 @@ import SwiftSyntaxMacros
 @_implementationOnly import SwiftSyntaxBuilder
 @_implementationOnly import SwiftDiagnostics
 
-let defaultStorageTypeName: TokenSyntax = "_$COWStorage"
-let defaultStorageName: TokenSyntax = "_$storage"
+internal let defaultStorageTypeName: TokenSyntax = "_$COWStorage"
+internal let defaultStorageName: TokenSyntax = "_$storage"
 
 // MARK: - NameLookupable
 

--- a/Sources/COWMacros/COWMacros.swift
+++ b/Sources/COWMacros/COWMacros.swift
@@ -5,8 +5,7 @@ import SwiftSyntaxMacros
 @_implementationOnly import SwiftSyntaxBuilder
 @_implementationOnly import SwiftDiagnostics
 
-internal let defaultStorageTypeName: TokenSyntax = "_$COWStorage"
-internal let defaultStorageName: TokenSyntax = "_$storage"
+private let defaultStorageName: TokenSyntax = "_$storage"
 
 // MARK: - NameLookupable
 
@@ -102,10 +101,9 @@ public struct COWMacro:
       return []
     }
     
-    let storageTypeAndAssociatedMembers = factory.getStorageTypeDecl()
-    let storageTypeDecl = storageTypeAndAssociatedMembers.storageType
-    
     let storageName = structDecl.copyOnWriteStorageName ?? defaultStorageName
+    let storageTypeAndAssociatedMembers = factory.getStorageTypeDecl(storageName: storageName)
+    let storageTypeDecl = storageTypeAndAssociatedMembers.storageType
     
     // Create storage member
     let storageMemberDecl = factory.createStorageVarDecl(

--- a/Sources/COWMacros/SyntaxExtensions.swift
+++ b/Sources/COWMacros/SyntaxExtensions.swift
@@ -121,7 +121,7 @@ extension StructDeclSyntax {
 
 extension FunctionSignatureSyntax {
   
-  var hasThrows: Bool {
+  internal var hasThrows: Bool {
     effectSpecifiers?.throwsSpecifier?.tokenKind == .keyword(.`throws`)
   }
   
@@ -140,11 +140,11 @@ extension FunctionDeclSyntax {
     return false
   }
   
-  var isMutating: Bool {
+  internal var isMutating: Bool {
     modifiers.contains(where: { $0.name.tokenKind == .keyword(.`mutating`) })
   }
   
-  func returnTypeEquals(to type: String) -> Bool {
+  internal func returnTypeEquals(to type: String) -> Bool {
     guard let returnClause = signature.returnClause,
           let returnType = returnClause.type.as(IdentifierTypeSyntax.self) else {
       return type == "Void"
@@ -154,7 +154,7 @@ extension FunctionDeclSyntax {
   
   // Equatable:
   // static func == (lhs: Self, rhs: Self) -> Bool
-  func likelyToConformToEquatable(for structDecl: StructDeclSyntax) -> Bool {
+  internal func likelyToConformToEquatable(for structDecl: StructDeclSyntax) -> Bool {
     guard isStatic else {
       return false
     }
@@ -186,7 +186,7 @@ extension FunctionDeclSyntax {
   
   // Hashable:
   // func hash(into hasher: inout Hasher)
-  var likelyToConformToHashable: Bool {
+  internal var likelyToConformToHashable: Bool {
     guard !isStatic,
           name.trimmed.text == "hash",
           returnTypeEquals(to: "Void") else {
@@ -209,7 +209,7 @@ extension FunctionDeclSyntax {
   
   // Encodable:
   // func encode(to encoder: any Encoder) throws
-  var likelyToConformToEncodable: Bool {
+  internal var likelyToConformToEncodable: Bool {
     guard !isStatic,
           name.trimmed.text == "encode",
           returnTypeEquals(to: "Void"),
@@ -497,7 +497,7 @@ extension InitializerDeclSyntax {
   
   // Decodable:
   // init(from decoder: any Decoder) throws
-  var likelyToConformToDecodable: Bool {
+  internal var likelyToConformToDecodable: Bool {
     guard signature.hasThrows else {
       return false
     }
@@ -765,27 +765,27 @@ extension SwitchCaseSyntax {
   
 }
 
-let equatableProtocolNames: Set<String> = [
+internal let equatableProtocolNames: Set<String> = [
   "Equatable",
   "Swift.Equatable"
 ]
 
-let hashableProtocolNames: Set<String> = [
+internal let hashableProtocolNames: Set<String> = [
   "Hashable",
   "Swift.Hashable"
 ]
 
-let codableProtocolNames: Set<String> = [
+internal let codableProtocolNames: Set<String> = [
   "Codable",
   "Swift.Codable"
 ]
 
-let encodableProtocolNames: Set<String> = [
+internal let encodableProtocolNames: Set<String> = [
   "Encodable",
   "Swift.Encodable"
 ]
 
-let decodableProtocolNames: Set<String> = [
+internal let decodableProtocolNames: Set<String> = [
   "Decodable",
   "Swift.Decodable"
 ]
@@ -798,7 +798,7 @@ private let autoSynthesizingProtocolTypes: Set<String> =
     .union(decodableProtocolNames)
 
 extension InheritedTypeListSyntax {
-  func containsType(named typeName: String) -> Bool {
+  internal func containsType(named typeName: String) -> Bool {
     contains(where: {
       guard let identifier = $0.type.identifier else {
         return false

--- a/Sources/COWMacros/SyntaxExtensions.swift
+++ b/Sources/COWMacros/SyntaxExtensions.swift
@@ -119,6 +119,14 @@ extension StructDeclSyntax {
   
 }
 
+extension FunctionSignatureSyntax {
+  
+  var hasThrows: Bool {
+    effectSpecifiers?.throwsSpecifier?.tokenKind == .keyword(.`throws`)
+  }
+  
+}
+
 extension FunctionDeclSyntax {
   
   internal var isStatic: Bool {
@@ -128,6 +136,107 @@ extension FunctionDeclSyntax {
           return true
         }
       }
+    }
+    return false
+  }
+  
+  var isMutating: Bool {
+    modifiers.contains(where: { $0.name.tokenKind == .keyword(.`mutating`) })
+  }
+  
+  func returnTypeEquals(to type: String) -> Bool {
+    guard let returnClause = signature.returnClause,
+          let returnType = returnClause.type.as(IdentifierTypeSyntax.self) else {
+      return type == "Void"
+    }
+    return returnType.name.trimmed.text == type
+  }
+  
+  // Equatable:
+  // static func == (lhs: Self, rhs: Self) -> Bool
+  func likelyToConformToEquatable(for structDecl: StructDeclSyntax) -> Bool {
+    guard isStatic else {
+      return false
+    }
+    guard name.tokenKind == .binaryOperator("=="),
+          returnTypeEquals(to: "Bool") else {
+      return false
+    }
+    let params = signature.parameterClause.parameters
+    guard params.count == 2 else {
+      return false
+    }
+    guard let lhs = params.first, let rhs = params.last else {
+      return false
+    }
+    guard lhs.firstName.trimmed.text == "lhs",
+          rhs.firstName.trimmed.text == "rhs",
+          let lhsType = lhs.type.as(IdentifierTypeSyntax.self),
+          let rhsType = rhs.type.as(IdentifierTypeSyntax.self),
+          lhsType.name.tokenKind == rhsType.name.tokenKind else {
+      return false
+    }
+    // Accept either `Self` or the name of the struct.
+    guard lhsType.name.tokenKind == .keyword(.`Self`) ||
+            lhsType.name.tokenKind == structDecl.name.tokenKind else {
+      return false
+    }
+    return true
+  }
+  
+  // Hashable:
+  // func hash(into hasher: inout Hasher)
+  var likelyToConformToHashable: Bool {
+    guard !isStatic,
+          name.trimmed.text == "hash",
+          returnTypeEquals(to: "Void") else {
+      return false
+    }
+    let params = signature.parameterClause.parameters
+    guard params.count == 1 else {
+      return false
+    }
+    let singleParam = params.first!
+    guard singleParam.firstName.trimmed.text == "into",
+          let paramType = singleParam.type.as(AttributedTypeSyntax.self),
+          paramType.specifier?.tokenKind == .keyword(.`inout`),
+          let baseParamType = paramType.baseType.as(IdentifierTypeSyntax.self),
+          baseParamType.name.trimmed.text == "Hasher" else {
+      return false
+    }
+    return true
+  }
+  
+  // Encodable:
+  // func encode(to encoder: any Encoder) throws
+  var likelyToConformToEncodable: Bool {
+    guard !isStatic,
+          name.trimmed.text == "encode",
+          returnTypeEquals(to: "Void"),
+          signature.hasThrows else {
+      return false
+    }
+    let params = signature.parameterClause.parameters
+    guard params.count == 1 else {
+      return false
+    }
+    let singleParam = params.first!
+    guard singleParam.firstName.trimmed.text == "to" else {
+      return false
+    }
+    // Existential any will be a requirement in the future release of Swift.
+    // For now, accept both `any Encoder` and `Encoder`.
+    if let paramType = singleParam.type.as(SomeOrAnyTypeSyntax.self) {
+      guard paramType.someOrAnySpecifier.tokenKind == .keyword(.`any`),
+            let type = paramType.constraint.as(IdentifierTypeSyntax.self),
+            type.name.trimmed.text == "Encoder" else {
+        return false
+      }
+      return true
+    }
+    guard let paramType = singleParam.type.as(IdentifierTypeSyntax.self),
+          paramType.name.trimmed.text == "Encoder" else {
+      return false
     }
     return true
   }
@@ -152,8 +261,12 @@ extension VariableDeclSyntax {
     return hasMacroApplication(COWExcludedMacro.name)
   }
   
+  internal var isStored: Bool {
+    return bindings.allSatisfy(\.isStored)
+  }
+  
   internal var isNotExcludedAndStored: Bool {
-    return !isExcluded && bindings.allSatisfy(\.isStored) && !isStatic
+    return !isExcluded && isStored && !isStatic
   }
   
   internal var isStatic: Bool {
@@ -380,6 +493,37 @@ extension InitializerDeclSyntax {
   
   internal func isEquivalent(to other: InitializerDeclSyntax) -> Bool {
     return signatureStandin == other.signatureStandin
+  }
+  
+  // Decodable:
+  // init(from decoder: any Decoder) throws
+  var likelyToConformToDecodable: Bool {
+    guard signature.hasThrows else {
+      return false
+    }
+    let params = signature.parameterClause.parameters
+    guard params.count == 1 else {
+      return false
+    }
+    let singleParam = params.first!
+    guard singleParam.firstName.trimmed.text == "from" else {
+      return false
+    }
+    // Existential any will be a requirement in the future release of Swift.
+    // For now, accept both `any Decoder` and `Decoder`.
+    if let paramType = singleParam.type.as(SomeOrAnyTypeSyntax.self) {
+      guard paramType.someOrAnySpecifier.tokenKind == .keyword(.`any`),
+            let type = paramType.constraint.as(IdentifierTypeSyntax.self),
+            type.name.trimmed.text == "Decoder" else {
+        return false
+      }
+      return true
+    }
+    guard let paramType = singleParam.type.as(IdentifierTypeSyntax.self),
+          paramType.name.trimmed.text == "Decoder" else {
+      return false
+    }
+    return true
   }
   
 }
@@ -621,18 +765,48 @@ extension SwitchCaseSyntax {
   
 }
 
-private let autoSynthesizingProtocolTypes: Set<String> = [
+let equatableProtocolNames: Set<String> = [
   "Equatable",
-  "Swift.Equatable",
-  "Hashable",
-  "Swift.Hashable",
-  "Codable",
-  "Swift.Codable",
-  "Encodable",
-  "Swift.Encodable",
-  "Decodable",
-  "Swift.Decodable",
+  "Swift.Equatable"
 ]
+
+let hashableProtocolNames: Set<String> = [
+  "Hashable",
+  "Swift.Hashable"
+]
+
+let codableProtocolNames: Set<String> = [
+  "Codable",
+  "Swift.Codable"
+]
+
+let encodableProtocolNames: Set<String> = [
+  "Encodable",
+  "Swift.Encodable"
+]
+
+let decodableProtocolNames: Set<String> = [
+  "Decodable",
+  "Swift.Decodable"
+]
+
+private let autoSynthesizingProtocolTypes: Set<String> =
+  equatableProtocolNames
+    .union(hashableProtocolNames)
+    .union(codableProtocolNames)
+    .union(encodableProtocolNames)
+    .union(decodableProtocolNames)
+
+extension InheritedTypeListSyntax {
+  func containsType(named typeName: String) -> Bool {
+    contains(where: {
+      guard let identifier = $0.type.identifier else {
+        return false
+      }
+      return identifier == typeName
+    })
+  }
+}
 
 extension DeclGroupSyntax {
   
@@ -643,14 +817,124 @@ extension DeclGroupSyntax {
       return []
     }
     
-    guard let inheritedTypes
+    guard var inheritedTypes
             = structDecl.inheritanceClause?.inheritedTypes else {
       return []
     }
     
+    var hasHashableImpl = false
+    var hasEquatableImpl = false
+    var hasEncodableImpl = false
+    var hasDecodableImpl = false
+    
+    for member in structDecl.memberBlock.members {
+      if hasHashableImpl,
+         hasEquatableImpl,
+         hasEncodableImpl,
+         hasDecodableImpl {
+        break
+      }
+      
+      if !hasEquatableImpl || !hasHashableImpl || !hasEncodableImpl,
+         let functionDecl = member.decl.as(FunctionDeclSyntax.self) {
+        if !hasEquatableImpl {
+          hasEquatableImpl = functionDecl.likelyToConformToEquatable(for: structDecl)
+          if hasEquatableImpl {
+            continue
+          }
+        }
+        if !hasHashableImpl {
+          hasHashableImpl = functionDecl.likelyToConformToHashable
+          if hasHashableImpl {
+            continue
+          }
+        }
+        if !hasEncodableImpl {
+          hasEncodableImpl = functionDecl.likelyToConformToEncodable
+          if hasEncodableImpl {
+            continue
+          }
+        }
+      } else if !hasDecodableImpl,
+                let initializerDecl = member.decl.as(InitializerDeclSyntax.self) {
+        hasDecodableImpl = initializerDecl.likelyToConformToDecodable
+      }
+    }
+    
+    // Only conform to the protocols if custom implementation is absent.
+    var protocolsToConform = autoSynthesizingProtocolTypes
+    
+    if hashableProtocolNames.contains(where: inheritedTypes.containsType(named:)) {
+      if hasHashableImpl {
+        protocolsToConform.subtract(hashableProtocolNames)
+      }
+      // Hashable implies Equatable.
+      // FIXME: compiler bug, must unconditionally conform to Equatable
+      #if true
+      inheritedTypes.append(
+        InheritedTypeSyntax(
+          type: IdentifierTypeSyntax(
+            name: "Swift.Equatable"
+          )
+        )
+      )
+      #else
+      if !hasEquatableImpl {
+        inheritedTypes.append(
+          InheritedTypeSyntax(
+            type: IdentifierTypeSyntax(
+              name: "Swift.Equatable"
+            )
+          )
+        )
+      }
+      #endif
+    }
+    
+    // FIXME: compiler bug
+    #if false
+    if equatableProtocolNames.contains(where: inheritedTypes.containsType(named:)),
+       hasEquatableImpl {
+      protocolsToConform.subtract(equatableProtocolNames)
+    }
+    #endif
+    
+    if hasEncodableImpl || hasDecodableImpl {
+      protocolsToConform.subtract(codableProtocolNames)
+    }
+    if codableProtocolNames.contains(where: inheritedTypes.containsType(named:)) {
+      // Codable implies Encodable & Decodable.
+      if hasDecodableImpl, !hasEncodableImpl {
+        inheritedTypes.append(
+          InheritedTypeSyntax(
+            type: IdentifierTypeSyntax(
+              name: "Swift.Encodable"
+            )
+          )
+        )
+      } else if hasEncodableImpl, !hasDecodableImpl {
+        inheritedTypes.append(
+          InheritedTypeSyntax(
+            type: IdentifierTypeSyntax(
+              name: "Swift.Decodable"
+            )
+          )
+        )
+      }
+    } else {
+      if hasEncodableImpl,
+         encodableProtocolNames.contains(where: inheritedTypes.containsType(named:)) {
+        protocolsToConform.subtract(encodableProtocolNames)
+      }
+      if hasDecodableImpl,
+         decodableProtocolNames.contains(where: inheritedTypes.containsType(named:)) {
+        protocolsToConform.subtract(decodableProtocolNames)
+      }
+    }
+    
     return inheritedTypes.filter { each in
       if let ident = each.type.identifier {
-        if autoSynthesizingProtocolTypes.contains(ident) {
+        if protocolsToConform.contains(ident) {
           return true
         }
       }

--- a/Tests/COWIntegratedTests/COWTests.swift
+++ b/Tests/COWIntegratedTests/COWTests.swift
@@ -344,6 +344,39 @@ final class COWTests: XCTestCase {
     XCTAssertEqual(fee, foe)
   }
   
+  // The only difference between this test case and
+  // `ManuallyConformedEquatableStruct` is that `foo` is `@COWExcluded`.
+  // This test fails to compile with previous implementation of `==`
+  // workaround.
+  @COW
+  struct ManuallyConformedEquatableStruct2: Hashable {
+    
+    var value: Int = 0
+    var wrappedValue: Int { value }
+    
+    @COWExcluded
+    let foo = NotConformingToHashable()
+    
+    func hash(into hasher: inout Hasher) {
+      hasher.combine(value)
+    }
+    
+    static func == (lhs: Self, rhs: Self) -> Bool {
+      return lhs.wrappedValue == rhs.wrappedValue
+    }
+    
+  }
+  
+  func testManuallyConformedEquatableStruct2() {
+    var fee = ManuallyConformedEquatableStruct2()
+    let foe = fee
+    XCTAssertEqual(fee, foe)
+    fee.value = 100
+    XCTAssertNotEqual(fee, foe)
+    fee.value = 0
+    XCTAssertEqual(fee, foe)
+  }
+  
   @COW
   struct CodableStruct: Codable {
     

--- a/Tests/COWIntegratedTests/COWTests.swift
+++ b/Tests/COWIntegratedTests/COWTests.swift
@@ -461,6 +461,32 @@ final class COWTests: XCTestCase {
   }
   
   @COW
+  struct CodableStructWithCustomStorageType: Codable {
+    
+    @COWStorage
+    struct CustomStorage: Codable {
+      
+    }
+    
+    var value: Int = 0
+    
+  }
+  
+  func testCodableStructWithCustomStorageType() {
+    var fee = CodableStructWithCustomStorageType()
+    primitiveTestCRUD(&fee, properties: (\.value, 0, 100))
+    do {
+      let encoder = JSONEncoder()
+      let data = try encoder.encode(fee)
+      let decoder = JSONDecoder()
+      let codededFee = try decoder.decode(CodableStruct.self, from: data)
+      XCTAssertEqual(fee.value, codededFee.value)
+    } catch _ {
+      XCTFail()
+    }
+  }
+  
+  @COW
   struct HashableStruct: Hashable {
     
     var value: Int = 0

--- a/Tests/COWIntegratedTests/COWTests.swift
+++ b/Tests/COWIntegratedTests/COWTests.swift
@@ -376,6 +376,37 @@ final class COWTests: XCTestCase {
     fee.value = 0
     XCTAssertEqual(fee, foe)
   }
+
+  @COW
+  struct ManuallyConformedEquatableStructWithCustomStorage: Hashable {
+    
+    @COWStorage
+    struct CustomStorage {
+      
+    }
+    
+    var value: Int = 0
+    var wrappedValue: Int { value }
+    
+    func hash(into hasher: inout Hasher) {
+      hasher.combine(value)
+    }
+    
+    static func == (lhs: Self, rhs: Self) -> Bool {
+      return lhs.wrappedValue == rhs.wrappedValue
+    }
+    
+  }
+  
+  func testManuallyConformedEquatableStructWithCustomStorage() {
+    var fee = ManuallyConformedEquatableStructWithCustomStorage()
+    let foe = fee
+    XCTAssertEqual(fee, foe)
+    fee.value = 100
+    XCTAssertNotEqual(fee, foe)
+    fee.value = 0
+    XCTAssertEqual(fee, foe)
+  }
   
   @COW
   struct CodableStruct: Codable {

--- a/Tests/COWMacrosTests/COWMacroOLoCTests.swift
+++ b/Tests/COWMacrosTests/COWMacroOLoCTests.swift
@@ -249,57 +249,6 @@ final class COWMacroOLoCTests: XCTestCase {
     )
   }
   
-  /// Does not break the behavior of auto synthesizing protocols.
-  ///
-  /// `Hashable`, `Codeable` shall also work.
-  ///
-  /// The original struct:
-  ///
-  /// ```
-  /// struct Foo: Equatable {
-  ///
-  ///   var value: Int = 0
-  ///
-  /// }
-  /// ```
-  ///
-  func testStructWithPropertyAndConformsToAutoSynthesizingProtocols() {
-    assertMacroExpansion(
-      """
-      @COW
-      struct Foo: Equatable {
-      
-        var value: Int = 0
-      
-      }
-      """,
-      expandedSource:
-      """
-      
-      struct Foo: Equatable {
-
-        var value: Int = 0 {
-          _read {
-            yield _$storage.value
-          }
-          _modify {
-            yield &_$storage.value
-          }
-        }
-
-        struct _$COWStorage: COW.CopyOnWriteStorage, Equatable {
-          var value: Int = 0
-        }
-        @COW._Box
-        var _$storage: _$COWStorage = _$COWStorage()
-
-      }
-      """,
-      macros: testedMacros,
-      indentationWidth: .spaces(2)
-    )
-  }
-  
   /// Do not expand on static properties.
   ///
   /// The original struct:

--- a/Tests/COWMacrosTests/COWMacroProtocolConformanceTests.swift
+++ b/Tests/COWMacrosTests/COWMacroProtocolConformanceTests.swift
@@ -1,0 +1,321 @@
+//
+//  COWMacroProtocolConformanceTests.swift
+//
+//
+//  Created by jiangzhaoxuan on 2024/3/6.
+//
+
+@_implementationOnly import SwiftSyntaxMacros
+@_implementationOnly import SwiftSyntaxMacrosTestSupport
+@_implementationOnly import XCTest
+
+@testable import COWMacros
+
+/// Tests cases related to `Hashable`, `Equatable`, `Codable`, etc.
+///
+final class COWMacroProtocolConformanceTests: XCTestCase {
+  
+  /// Does not break the behavior of auto synthesizing protocols.
+  ///
+  /// `Hashable`, `Codeable` shall also work.
+  ///
+  /// The original struct:
+  ///
+  /// ```
+  /// struct Foo: Equatable {
+  ///
+  ///   var value: Int = 0
+  ///
+  /// }
+  /// ```
+  ///
+  func testStructWithPropertyAndConformsToAutoSynthesizingProtocols() {
+    assertMacroExpansion(
+      """
+      @COW
+      struct Foo: Equatable {
+      
+        var value: Int = 0
+      
+      }
+      """,
+      expandedSource:
+      """
+      
+      struct Foo: Equatable {
+
+        var value: Int = 0 {
+          _read {
+            yield _$storage.value
+          }
+          _modify {
+            yield &_$storage.value
+          }
+        }
+
+        struct _$COWStorage: COW.CopyOnWriteStorage, Equatable {
+          var value: Int = 0
+        }
+        @COW._Box
+        var _$storage: _$COWStorage = _$COWStorage()
+
+      }
+      """,
+      macros: testedMacros,
+      indentationWidth: .spaces(2)
+    )
+  }
+  
+  // FIXME: There is a compiler bug that breaks the build if the nested struct
+  // does not conform to Equatable where the nesting struct does.
+  // We have an integrated test case covering all the necessary workarounds:
+  // see COWTest.testManuallyConformedEquatableStruct.
+  // Remove the conditional compilation lines when the compiler bug is fixed.
+  #if false
+  /// Do not conform to `Equatable` if user explicitly declares `==`.
+  ///
+  /// The original struct:
+  ///
+  /// ```
+  /// struct Foo: Equatable {
+  ///
+  ///   var value: Int = 0
+  ///
+  ///   static func == (lhs: Self, rhs: Self) -> Bool {
+  ///     lhs.value == rhs.value
+  ///   }
+  ///
+  /// }
+  /// ```
+  func testStructWithManualEquatableConformance() {
+    assertMacroExpansion(
+      """
+      @COW
+      struct Foo: Equatable {
+      
+        var value: Int = 0
+        
+        static func == (lhs: Self, rhs: Self) -> Bool {
+          lhs.value == rhs.value
+        }
+      
+      }
+      """,
+      expandedSource:
+      """
+      
+      struct Foo: Equatable {
+
+        var value: Int = 0 {
+          _read {
+            yield _$storage.value
+          }
+          _modify {
+            yield &_$storage.value
+          }
+        }
+        
+        static func == (lhs: Self, rhs: Self) -> Bool {
+          lhs.value == rhs.value
+        }
+      
+        struct _$COWStorage: COW.CopyOnWriteStorage {
+          var value: Int = 0
+        }
+        @COW._Box
+        var _$storage: _$COWStorage = _$COWStorage()
+      
+      }
+      """,
+      macros: testedMacros,
+      indentationWidth: .spaces(2)
+    )
+  }
+  #endif
+  
+  /// Do not conform to `Hashable` if user explicitly declares `hash(into:)`.
+  /// Conform to `Equatable` because `Hashable` implies such requirement.
+  ///
+  /// The original struct:
+  ///
+  /// ```
+  /// struct Foo: Hashable {
+  ///
+  ///   var value: Int = 0
+  ///
+  ///   func hash(into hasher: inout Hasher) {
+  ///     hasher.combine(value)
+  ///   }
+  ///
+  /// }
+  /// ```
+  func testStructWithManualHashableConformance() {
+    assertMacroExpansion(
+      """
+      @COW
+      struct Foo: Hashable {
+      
+        var value: Int = 0
+        
+        func hash(into hasher: inout Hasher) {
+          hasher.combine(value)
+        }
+      
+      }
+      """,
+      expandedSource:
+      """
+      
+      struct Foo: Hashable {
+
+        var value: Int = 0 {
+          _read {
+            yield _$storage.value
+          }
+          _modify {
+            yield &_$storage.value
+          }
+        }
+        
+        func hash(into hasher: inout Hasher) {
+          hasher.combine(value)
+        }
+
+        struct _$COWStorage: COW.CopyOnWriteStorage, Swift.Equatable {
+          var value: Int = 0
+        }
+        @COW._Box
+        var _$storage: _$COWStorage = _$COWStorage()
+
+      }
+      """,
+      macros: testedMacros,
+      indentationWidth: .spaces(2)
+    )
+  }
+  
+  /// Do not conform to `Decodable` if user explicitly declares `init(from:)`.
+  /// Conform to `Encodable` because `Codable` = `Decodable` + `Encodable`.
+  ///
+  /// The original struct:
+  ///
+  /// ```
+  /// struct Foo: Codable {
+  ///
+  ///   var value: Int = 0
+  ///
+  ///   init(from decoder: Decoder) throws {
+  ///     self.init(value: try decoder.singleValueContainer().decode(Int.self))
+  ///   }
+  ///
+  /// }
+  /// ```
+  func testStructWithManualDecodableConformance() {
+    assertMacroExpansion(
+      """
+      @COW
+      struct Foo: Codable {
+      
+        var value: Int = 0
+      
+        init(from decoder: Decoder) throws {
+          self.init(value: try decoder.singleValueContainer().decode(Int.self))
+        }
+      
+      }
+      """,
+      expandedSource:
+      """
+      
+      struct Foo: Codable {
+
+        var value: Int = 0 {
+          _read {
+            yield _$storage.value
+          }
+          _modify {
+            yield &_$storage.value
+          }
+        }
+
+        init(from decoder: Decoder) throws {
+          self.init(value: try decoder.singleValueContainer().decode(Int.self))
+        }
+
+        struct _$COWStorage: COW.CopyOnWriteStorage, Swift.Encodable {
+          var value: Int = 0
+        }
+        @COW._Box
+        var _$storage: _$COWStorage = _$COWStorage()
+
+      }
+      """,
+      macros: testedMacros,
+      indentationWidth: .spaces(2)
+    )
+  }
+  
+  /// Do not conform to `Encodable` if user explicitly declares `encode(to:)`.
+  /// Conform to `Decodable` because `Codable` = `Decodable` + `Encodable`.
+  ///
+  /// The original struct:
+  ///
+  /// ```
+  /// struct Foo: Codable {
+  ///
+  ///   var value: Int = 0
+  ///
+  ///   func encode(to encoder: Encoder) throws {
+  ///     let container = encoder.singleValueContainer()
+  ///     try container.encode(value)
+  ///   }
+  ///
+  /// }
+  /// ```
+  func testStructWithManualEncodableConformance() {
+    assertMacroExpansion(
+      """
+      @COW
+      struct Foo: Codable {
+      
+        var value: Int = 0
+      
+        func encode(to encoder: Encoder) throws {
+          let container = encoder.singleValueContainer()
+          try container.encode(value)
+        }
+      
+      }
+      """,
+      expandedSource:
+      """
+      
+      struct Foo: Codable {
+
+        var value: Int = 0 {
+          _read {
+            yield _$storage.value
+          }
+          _modify {
+            yield &_$storage.value
+          }
+        }
+
+        func encode(to encoder: Encoder) throws {
+          let container = encoder.singleValueContainer()
+          try container.encode(value)
+        }
+
+        struct _$COWStorage: COW.CopyOnWriteStorage, Swift.Decodable {
+          var value: Int = 0
+        }
+        @COW._Box
+        var _$storage: _$COWStorage = _$COWStorage()
+
+      }
+      """,
+      macros: testedMacros,
+      indentationWidth: .spaces(2)
+    )
+  }
+}


### PR DESCRIPTION
- Derived storage should not conform to the auto-conforming protocols if its containing struct manually implements the requirement.
- Tons of workarounds for Equatable-related compiler bugs.
- Support for CodingKeys.