### PR TITLE
Drop the access control modifiers for properties in the storage

### DIFF
--- a/Sources/COWMacros/COWExpansionFactory.swift
+++ b/Sources/COWMacros/COWExpansionFactory.swift
@@ -113,7 +113,15 @@ internal class COWExpansionFactory<Context: MacroExpansionContext> {
     storageName: TokenSyntax
   ) -> StorageTypeAndAssociatedMembers {
     var members = appliedStructValidVarDecls.map {
-      return MemberBlockItemSyntax(decl: $0)
+      // If a given member is modified with `private`, then we must drop it in
+      // the storage to allow outer synthesized accessors to visit it. For
+      // simplicity, all kinds of access control modifiers are unconditionally
+      // dropped.
+      var varDecl = $0
+      varDecl.modifiers = varDecl.modifiers.filter {
+        $0.accessControlModifier == nil
+      }
+      return MemberBlockItemSyntax(decl: varDecl)
     }
     var protocols = appliedStructDecl.collectAutoSynthesizingProtocolConformance()
     var associatedMembers = [any DeclSyntaxProtocol]()

--- a/Sources/COWMacros/SyntaxExtensions.swift
+++ b/Sources/COWMacros/SyntaxExtensions.swift
@@ -243,6 +243,20 @@ extension FunctionDeclSyntax {
   
 }
 
+extension DeclModifierSyntax {
+  internal var accessControlModifier: Keyword? {
+    guard case let .keyword(keyword) = name.tokenKind else {
+      return nil
+    }
+    switch keyword {
+    case .`fileprivate`, .`internal`, .`open`, .`private`, .`public`:
+      return keyword
+    default:
+      return nil
+    }
+  }
+}
+
 extension VariableDeclSyntax {
   
   internal var isVarBinding: Bool {

--- a/Tests/COWIntegratedTests/COWTests.swift
+++ b/Tests/COWIntegratedTests/COWTests.swift
@@ -459,7 +459,7 @@ final class COWTests: XCTestCase {
       XCTFail()
     }
   }
-  
+
   @COW
   struct CodableStructWithCustomStorageType: Codable {
     
@@ -497,6 +497,40 @@ final class COWTests: XCTestCase {
     var fee = HashableStruct()
     primitiveTestCRUD(&fee, properties: (\.value, 0, 100))
     XCTAssertEqual(fee.hashValue, fee.hashValue)
+  }
+
+  @COW
+  struct StructWithPrivateProperties {
+  
+    private var bar: Int
+    var getBar: Int { bar }
+  
+  }
+  
+  func testStructWithPrivateProperties() {
+    let foo = StructWithPrivateProperties(bar: 100)
+    // Macro expansions that does not drop the access control modifier will
+    // fail to compile - we must explicitly use the affected properties to
+    // trigger it.
+    XCTAssertEqual(foo.getBar, 100)
+  }
+
+  @COW
+  struct StructWithPrivatePropertiesAndCustomStorage {
+  
+    private var bar: Int
+    var getBar: Int { bar }
+
+    @COWStorage
+    struct CustomStorage {
+      
+    }
+  
+  }
+  
+  func testStructWithPrivatePropertiessAndCustomStorage() {
+    let foo = StructWithPrivatePropertiesAndCustomStorage(bar: 100)
+    XCTAssertEqual(foo.getBar, 100)
   }
   
   // MARK: Utilities

--- a/Tests/COWMacrosTests/COWMacroOLoCTests.swift
+++ b/Tests/COWMacrosTests/COWMacroOLoCTests.swift
@@ -305,5 +305,57 @@ final class COWMacroOLoCTests: XCTestCase {
     )
   }
 
+  /// Drop the access control modifiers for properties in the storage.
+  ///
+  /// The original struct:
+  ///
+  /// ```
+  /// struct Foo {
+  ///
+  ///   private var bar: Int
+  ///
+  /// }
+  /// ```
+  ///
+  func testStructWithPrivateProperties() {
+    assertMacroExpansion(
+      """
+      @COW
+      struct Foo {
+      
+        private var bar: Int
+      
+      }
+      """,
+      expandedSource:
+      """
+      
+      struct Foo {
+
+        private var bar: Int {
+          _read {
+            yield _$storage.bar
+          }
+          _modify {
+            yield &_$storage.bar
+          }
+        }
+
+        struct _$COWStorage: COW.CopyOnWriteStorage {
+          var bar: Int
+        }
+        @COW._Box
+        var _$storage: _$COWStorage
+
+        init(bar: Int) {
+          self._$storage = _$COWStorage(bar: bar)
+        }
+
+      }
+      """,
+      macros: testedMacros,
+      indentationWidth: .spaces(2)
+    )
+  }
 }
 


### PR DESCRIPTION
If a given member is modified with `private`, then we must drop it in the storage to allow outer synthesized accessors to visit it.